### PR TITLE
Fix for your question :) 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ async fn main() -> Result<()> {
 
     let mut interval = stream::interval(Duration::from_secs(5));
 
-    DownloadingProcessingPrintingActor::start_default().await?;
+    let _addr =DownloadingProcessingPrintingActor::start_default().await?;
 
     // a simple way to output a CSV header
     println!("period start,symbol,price,change %,min,max,30d avg");


### PR DESCRIPTION
Hi! It looks like not assigning the address will immediately drop the actor (similar results with using only an `_` assignment). 


~~~
     Running `target/debug/manning-lp-async-rust-project-1-m2-solution --from '2019-07-03T12:00:09Z' --symbols LYFT,MSFT,AAPL,UBER,LYFT,FB,AMD,GOOG`
subscribed
period start,symbol,price,change %,min,max,30d avg
publishing
handling
2019-07-03T12:00:09+00:00,AMD,$85.24,173.29%,$27.99,$97.25,$78.72
2019-07-03T12:00:09+00:00,UBER,$50.00,13.05%,$14.82,$63.18,$48.93
2019-07-03T12:00:09+00:00,LYFT,$59.27,-2.19%,$16.05,$67.45,$53.92
2019-07-03T12:00:09+00:00,GOOG,$2508.12,123.62%,$1056.62,$2527.04,$2406.63
2019-07-03T12:00:09+00:00,MSFT,$260.76,93.89%,$129.35,$261.37,$249.98
2019-07-03T12:00:09+00:00,LYFT,$59.27,-2.19%,$16.05,$67.45,$53.92
2019-07-03T12:00:09+00:00,FB,$332.95,68.84%,$146.01,$336.77,$323.57
2019-07-03T12:00:09+00:00,AAPL,$130.96,161.08%,$47.45,$142.70,$126.67
^C^J
~~~